### PR TITLE
Show build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # microprotect
 
+[![Build Status](https://github.com/microprotect/microprotect.com/workflows/CI/badge.svg?branch=master)](https://github.com/microprotect/microprotect.com/actions)
+
 ## Install dependencies
 
 ```bash


### PR DESCRIPTION
Add GitHub Actions **workflow status badge** on the top of `README.md` file.

See also:
- [Adding a workflow status badge to your repository](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository)

---

![Build Status](https://github.com/microprotect/microprotect.com/workflows/CI/badge.svg?branch=master)