### PR TITLE
Fix blur event handler of Vision component

### DIFF
--- a/src/components/Vision.jsx
+++ b/src/components/Vision.jsx
@@ -125,7 +125,7 @@ export default function Vision() {
               onMouseOver={() => handleMouseOver(word)}
               onMouseOut={handleMouseOut}
               onFocus={() => handleMouseOver(word)}
-              onBlur={handleMouseOver}
+              onBlur={handleMouseOut}
             >
               {word}
               {' '}


### PR DESCRIPTION
Change blur event handler to `handleMouseOut` because incorrect handler was set.