### PR TITLE
Resize Vision text by device width

### DIFF
--- a/src/components/Vision.jsx
+++ b/src/components/Vision.jsx
@@ -40,11 +40,11 @@ const styles = {
   },
   title: {
     margin: '0 auto',
-    maxWidth: '300px',
+    maxWidth: '70vw',
     lineHeight: '135%',
     letterSpacing: '.03em',
     fontFamily: 'Georgia',
-    fontSize: '2em',
+    fontSize: '8vw',
     fontWeight: 'normal',
     color: '#3ed7e8',
     textAlign: 'center',
@@ -116,9 +116,8 @@ export default function Vision() {
         ]}
         >
           {WORDS.map((word) => (
-            <>
+            <span key={word}>
               <span
-                key={word}
                 css={[
                   styles.word,
                   { opacity: !selectedWord || selectedWord === word ? 1 : 0.3 },
@@ -131,7 +130,7 @@ export default function Vision() {
                 {word}
               </span>
               {' '}
-            </>
+            </span>
           ))}
         </h1>
       </div>


### PR DESCRIPTION
Fix line break on mobile device.

Resize font size by device width.

![Screenshot](https://user-images.githubusercontent.com/46776329/72230956-04654d80-35fc-11ea-8954-607a46021cb0.png)
