### PR TITLE
Hack 404 handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           cp CNAME dist/
           cp favicon.ico dist/
           cp -r assets dist/
+          cp index.html dist/404.html
       - name: Deploy
         if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
Copy `index.html` to `404.html` for browser router on GitHub Pages.

See also:
- [Creating a custom 404 page for your GitHub Pages site](https://help.github.com/github/working-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site)