### PR TITLE
Use Google Analytics for React Router

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
         }
 
         gtag('js', new Date());
-        gtag('config', 'UA-153178350-1');
     </script>
 </head>
 <body>

--- a/src/components/HeaderV3.jsx
+++ b/src/components/HeaderV3.jsx
@@ -75,6 +75,11 @@ function Logo() {
 function OpenMenuButton({ active }) {
   const dispatch = useDispatch();
 
+  const handleClick = () => {
+    dispatch(openMenu());
+    window.postMessage({ type: 'open-menu' }, '*');
+  };
+
   return (
     <button
       css={[
@@ -82,7 +87,7 @@ function OpenMenuButton({ active }) {
         active ? styles.active : {},
       ]}
       type="button"
-      onClick={() => dispatch(openMenu())}
+      onClick={handleClick}
     >
       Menu
     </button>

--- a/src/components/Link.jsx
+++ b/src/components/Link.jsx
@@ -6,11 +6,12 @@ import { Link as RouterLink } from 'react-router-dom';
 
 export default function Link(props) {
   const handleClick = (event) => {
-    const { onClick } = props;
+    const { onClick, to } = props;
     if (onClick) {
       onClick(event);
     }
     window.scrollTo(0, 0);
+    window.postMessage({ type: 'pageview', path: to }, '*');
   };
 
   const { children } = props;

--- a/src/google-analytics.js
+++ b/src/google-analytics.js
@@ -1,5 +1,11 @@
 /* global gtag */
 
+const GA_MEASUREMENT_ID = 'UA-153178350-1';
+
+const EVENTS = [
+  'open-menu', 'play-video', 'subscribe', 'open-give-asia',
+];
+
 (() => {
   const { location } = window;
 
@@ -7,6 +13,7 @@
     return;
   }
 
+  gtag('config', 'UA-153178350-1');
   gtag('event', 'visit');
 
   const handleScroll = () => {
@@ -20,9 +27,13 @@
 
   window.addEventListener('scroll', handleScroll);
 
-  window.addEventListener('message', ({ data: { type } }) => {
-    if (['play-video', 'subscribe', 'open-give-asia'].includes(type)) {
+  window.addEventListener('message', ({ data: { type, path } }) => {
+    if (EVENTS.includes(type)) {
       gtag('event', type);
+    }
+
+    if (type === 'pageview') {
+      gtag('config', GA_MEASUREMENT_ID, { page_path: path });
     }
   });
 })();


### PR DESCRIPTION
Send pageview hit to Google Analytics when router link is clicked.

Send `open-menu` event to Google Analytics when user opens menu.

See also:
- [Google Analytics for Web (gtag.js) > Measure pageviews](https://developers.google.com/analytics/devguides/collection/gtagjs/pages)