### PR TITLE
Make header's background to transition

### DIFF
--- a/src/components/v4/Header.jsx
+++ b/src/components/v4/Header.jsx
@@ -1,17 +1,20 @@
 /* @jsx jsx */
 
-import React from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useState, useEffect } from 'react';
 
 import { jsx } from '@emotion/core';
+
+import { useDispatch } from 'react-redux';
 
 import { setLocale } from '../../appSlice';
 
 import { imageReplacement } from '../../styles/utils';
 import clearAfter from '../../styles/clearAfter';
+import { listContainer, listItem } from '../../styles/list';
 import {
   CONTENT_PADDING,
   BASE_MQ,
+  black,
 } from '../../styles/constants-v4';
 
 import { LogoImage } from '../../assets';
@@ -24,18 +27,23 @@ const styles = {
     left: 0,
     width: '100%',
     padding: '1em 5%',
+    backgroundColor: 'rgba(255, 255, 255, 0)',
+    boxShadow: '0 0 6px 0 rgba(200, 200, 200, 0)',
+    transition: '.3s ease-out',
     [BASE_MQ]: {
       padding: `1em ${CONTENT_PADDING}`,
     },
   },
   filled: {
-    background: 'rgba(255, 255, 255, 0.4)',
+    backgroundColor: 'rgba(255, 255, 255, 1)',
+    boxShadow: '0 0 6px 0 rgba(200, 200, 200, .5)',
   },
   logo: {
     float: 'left',
     display: 'block',
     width: '120px',
     height: '30px',
+    cursor: 'pointer',
     [BASE_MQ]: {
       width: '250px',
       height: '46px',
@@ -43,23 +51,29 @@ const styles = {
     ...imageReplacement(LogoImage),
   },
   languages: {
+    ...listContainer,
     float: 'right',
-    margin: 0,
-    padding: 0,
-    listStyle: 'none',
   },
   languageItem: {
+    ...listItem,
     float: 'left',
   },
   localeLink: {
     display: 'inline-block',
     padding: '0 .7em',
     height: '30px',
+    lineHeight: '30px',
+    color: black,
+    opacity: 0.5,
+    textDecoration: 'none',
     [BASE_MQ]: {
       height: '46px',
+      lineHeight: '46px',
+      fontSize: '1.3em',
     },
-    lineHeight: 1,
-    textDecoration: 'none',
+  },
+  current: {
+    opacity: 1,
   },
 };
 
@@ -76,7 +90,7 @@ function LocaleLink({ children, locale, target }) {
       href={`?locale=${target}`}
       css={[
         styles.localeLink,
-        locale === target ? { textDecoration: 'underline' } : {},
+        locale === target ? styles.current : {},
       ]}
       onClick={handleClick}
     >
@@ -85,16 +99,40 @@ function LocaleLink({ children, locale, target }) {
   );
 }
 
+function handleClickLogo() {
+  window.scroll({
+    top: 0,
+    left: 0,
+    behavior: 'smooth',
+  });
+}
+
 export default function Header({ locale }) {
+  const [filled, setFilled] = useState(false);
+
+  useEffect(() => {
+    window.addEventListener('scroll', () => {
+      setFilled(window.scrollY > 20);
+    });
+  });
+
   return (
     <header
       css={[
         styles.container,
-        styles.filled,
         clearAfter,
+        filled ? styles.filled : {},
       ]}
     >
-      <div id="logo" css={styles.logo}>microprotect</div>
+      <div
+        id="logo"
+        css={styles.logo}
+        role="button"
+        aria-hidden="true"
+        onClick={handleClickLogo}
+      >
+        Microprotect
+      </div>
       <ul css={styles.languages}>
         <li css={styles.languageItem}>
           <LocaleLink locale={locale} target="ko">Korean</LocaleLink>

--- a/src/components/v4/HeaderPanel.jsx
+++ b/src/components/v4/HeaderPanel.jsx
@@ -35,8 +35,9 @@ const styles = {
     height: '125vw',
     [BASE_MQ]: {
       margin: '0 auto',
+      padding: 0,
       maxWidth: `${width}px`,
-      height: `${height}px`,
+      maxHeight: `${height}px`,
     },
   },
   sprite: {
@@ -58,14 +59,14 @@ const styles = {
   slogan: {
     position: 'relative',
     margin: 0,
-    marginTop: '2.5em',
+    paddingTop: '2.5em',
     fontFamily: 'BMJUA',
     fontSize: '8vw',
     fontWeight: '300',
     letterSpacing: '.1vw',
     textTransform: 'capitalize',
     [BASE_MQ]: {
-      marginTop: '1.4em',
+      paddingTop: '1.4em',
       fontSize: '6em',
     },
   },


### PR DESCRIPTION
Show and hide background of `Header` component by scroll event.

Change design of language select menu.

![Screenshot #1](https://user-images.githubusercontent.com/36392/73475850-88794c80-43d4-11ea-9b46-e69226dea4b1.png)

![Screenshot #2](https://user-images.githubusercontent.com/36392/73475852-8911e300-43d4-11ea-854a-30c90532800e.png)
