### PR TITLE
Fix carousel opacity and support iPad

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -23,6 +23,11 @@
     box-sizing: border-box;
 }
 
+html,
+body {
+    overflow-x: hidden;
+}
+
 body,
 input,
 button {

--- a/src/components/v5/MicroCare.jsx
+++ b/src/components/v5/MicroCare.jsx
@@ -29,6 +29,7 @@ const styles = {
     width: '200%',
     transition: '.3s ease-in-out',
     [BASE_MQ]: {
+      marginLeft: 0,
       width: '100%',
     },
   },
@@ -73,10 +74,10 @@ export default function MicroCare({ t }) {
   };
   const handleTouchEnd = () => {
     setOffset(0);
-    if (offset < -30) {
+    if (offset < -50) {
       setPage(2);
     }
-    if (offset > 30) {
+    if (offset > 50) {
       setPage(1);
     }
   };
@@ -95,8 +96,8 @@ export default function MicroCare({ t }) {
       >
         <ListContainer
           style={[
-            styles.items,
             { marginLeft: `calc(-${(page - 1) * 100}% + ${offset}px)` },
+            styles.items,
             offset ? { transition: '0s' } : {},
           ]}
         >

--- a/src/components/v5/MicroCareItem.jsx
+++ b/src/components/v5/MicroCareItem.jsx
@@ -51,8 +51,8 @@ const styles = {
     width: '100%',
     transition: '.3s ease-in-out',
   },
-  opacity: (active) => ({
-    opacity: active ? 1 : 0,
+  opacity: (opacity, active) => ({
+    opacity: active ? 1 : opacity,
     [BASE_MQ]: {
       opacity: 1,
     },
@@ -64,7 +64,7 @@ export default function MicroCareItem({ t, index, active }) {
     <div css={styles.container}>
       <div css={[
         styles.text,
-        styles.opacity(active),
+        styles.opacity(0, active),
       ]}
       >
         <h3 css={styles.title}>
@@ -81,7 +81,7 @@ export default function MicroCareItem({ t, index, active }) {
       <img
         css={[
           styles.image,
-          styles.opacity(active),
+          styles.opacity(0.5, active),
         ]}
         src={images[index - 1]}
         alt=""


### PR DESCRIPTION
Change opacity of macro-care carousel image.

Move carousel on mobile device only, and support iPad.

Disable scrolling from side to side.