### PR TITLE
Open KakaoTalk chat pages for Safari and Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 </div>
 <script>var clicky_site_ids = [101225647];</script>
 <script src="https://static.getclicky.com/js"></script>
+<script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
 <div class="fb-customerchat"
      attribution=setup_tool
      page_id="111858463618112"

--- a/src/components/ChatBubble.jsx
+++ b/src/components/ChatBubble.jsx
@@ -11,29 +11,38 @@ const styles = {
     position: 'fixed',
     right: '20px',
     bottom: '20px',
+    margin: 0,
+    padding: 0,
+    width: '64px',
+    height: '64px',
+    border: 0,
+    borderRadius: '50%',
+    boxShadow: '2px 2px 10px 0 rgba(200, 200, 200, 0.5)',
+    cursor: 'pointer',
   },
   image: {
     display: 'block',
-    width: '64px',
-    height: '64px',
-    borderRadius: '50%',
-    boxShadow: '2px 2px 10px 0 rgba(200, 200, 200, 0.5)',
+    width: '100%',
+    height: '100%',
   },
 };
 
 export default function ChatBubble() {
+  const handleClick = () => {
+    window.postMessage({ type: 'kakaotalk-chat' }, '*');
+  };
+
   return (
-    <a
+    <button
       css={styles.container}
-      href="https://pf.kakao.com/_MIvxjxb"
-      target="_blank"
-      rel="noopener noreferrer"
+      type="button"
+      onClick={handleClick}
     >
       <img
         css={styles.image}
         src={KakaoTalkChannelImage}
         alt="KakaoTalk"
       />
-    </a>
+    </button>
   );
 }

--- a/src/components/v5/InsuranceIntroduction.jsx
+++ b/src/components/v5/InsuranceIntroduction.jsx
@@ -40,6 +40,7 @@ const styles = {
     margin: '2em auto .5em',
     padding: '.6em 0',
     width: '85%',
+    border: 0,
     borderRadius: '2em',
     fontSize: '1.5em',
     background: '#2D65ED',
@@ -60,6 +61,10 @@ const underlinedToBold = css`
 `;
 
 export default function InsuranceIntroduction({ t, product }) {
+  const handleClick = () => {
+    window.postMessage({ type: 'kakaotalk-chat' }, '*');
+  };
+
   return (
     <Section>
       <div css={[styles.description, underlinedToBold]}>
@@ -74,14 +79,13 @@ export default function InsuranceIntroduction({ t, product }) {
       </h2>
       <InsurancePricing t={t} product={product} />
       <div css={styles.buttonContainer}>
-        <a
+        <button
           css={styles.button}
-          href="https://pf.kakao.com/_MIvxjxb"
-          target="_blank"
-          rel="noopener noreferrer"
+          type="button"
+          onClick={handleClick}
         >
           {t.insurance_application_button}
-        </a>
+        </button>
       </div>
     </Section>
   );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ import { setLocale, setVersion } from './appSlice';
 import App from './App';
 
 import './google-analytics';
-
+import './kakaotalk';
 import './give-asia';
 
 import './assets/css/main.css';

--- a/src/kakaotalk.js
+++ b/src/kakaotalk.js
@@ -1,0 +1,14 @@
+/* global Kakao */
+
+(() => {
+  Kakao.init('9fe7a8f4f11cef0577151a02e64d867a');
+
+  window.addEventListener('message', ({ data: { type } }) => {
+    if (type === 'kakaotalk-chat') {
+      Kakao.Channel.chat({
+        channelPublicId: '_MIvxjxb',
+      });
+      window.open('https://accounts.kakao.com/login?continue=http%3A%2F%2Fpf.kakao.com%2F_MIvxjxb%2Fchat', '_blank');
+    }
+  });
+})();


### PR DESCRIPTION
Open KakaoTalk chat pages:

1. Use KakaoTalk channel plug-in. This is this is fail on Chrome.

2. KakaoTalk log-in page. This is unfriendly, but only one way for Chrome.

See also:
- [카카오톡 채널 플러그인](https://developers.kakao.com/docs/js/kakao-talk-channel)