### PR TITLE
MADMAX-1196 Underline pressed link

### DIFF
--- a/src/components/Article.jsx
+++ b/src/components/Article.jsx
@@ -48,6 +48,9 @@ const PressItem = styled.li({
         right: '45px',
       },
     },
+    '&:focus strong': {
+      textDecoration: 'underline',
+    },
   },
   '& time': {
     fontSize: `${calculateRem(14)}`,

--- a/src/components/JumpTo.jsx
+++ b/src/components/JumpTo.jsx
@@ -48,6 +48,9 @@ const Figure = styled.figure({
         content: '""',
       },
     },
+    '&:focus strong': {
+      textDecoration: 'underline',
+    },
   },
   '& img': {
     display: 'block',

--- a/src/components/Team.jsx
+++ b/src/components/Team.jsx
@@ -131,6 +131,9 @@ const HiringlLinkTo = styled.div({
       transform: 'translate(0, -50%)',
       content: '""',
     },
+    '&:focus': {
+      textDecoration: 'underline',
+    },
   },
 });
 


### PR DESCRIPTION
Underline the link to catch eyes when pressed.

Issue: https://microprotect.atlassian.net/browse/MADMAX-1196

---

![Screenshot](https://user-images.githubusercontent.com/6149100/108684446-44ed0580-7536-11eb-92aa-7b9084244daa.png)
